### PR TITLE
Add Galaxy workflow metadata defaults

### DIFF
--- a/src/ewoksgalaxy/io.py
+++ b/src/ewoksgalaxy/io.py
@@ -3,15 +3,31 @@ from typing import Any
 from ewokscore.engine_interface import TaskGraph
 
 
+_DEFAULT_LICENSE = "MIT"
+_DEFAULT_CREATOR = [{"class": "Organization", "name": "ESRF"}]
+
+
+def _node_doc(node: dict) -> str:
+    return node.get("doc") or node.get("annotation") or f"Ewoks task {node['id']}"
+
+
+def _graph_doc(graph_metadata: dict[str, Any]) -> str:
+    return (
+        graph_metadata.get("doc")
+        or graph_metadata.get("annotation")
+        or graph_metadata.get("label")
+        or f"Ewoks workflow {graph_metadata['id']}"
+    )
+
+
 def _ewoks_node_to_galaxy_step(node: dict) -> dict[str, Any]:
     step: dict[str, Any] = {
+        "doc": _node_doc(node),
+        "label": node.get("label") or node["id"],
         "tool_id": node["task_identifier"],
         "type": "tool",
         "out": [],  # required according to specs but unused in real Galaxy workflows?
     }
-    label = node.get("label")
-    if label is not None:
-        step["label"] = label
 
     default_inputs = node.get("default_inputs")
     if not default_inputs:
@@ -41,13 +57,17 @@ def _ewoks_link_to_galaxy_input(link: dict, galaxy_step_indices: dict[str, str])
 def ewoks_to_galaxy(raw_graph: TaskGraph) -> dict[str, Any]:
     graph_dict = raw_graph.dump()
 
+    graph_metadata: dict[str, Any] = graph_dict["graph"]
     galaxy_graph: dict[str, Any] = {
         "class": "GalaxyWorkflow",
+        "creator": graph_metadata.get("creator") or _DEFAULT_CREATOR,
+        "doc": _graph_doc(graph_metadata),
         "inputs": [],  # TODO
+        "license": graph_metadata.get("license") or _DEFAULT_LICENSE,
         "outputs": [],  # TODO
+        "tags": graph_metadata.get("tags", []),
     }
 
-    graph_metadata: dict[str, str] = graph_dict["graph"]
     graph_id = graph_metadata.get("id")
     if graph_id is not None:
         galaxy_graph["id"] = graph_id

--- a/src/ewoksgalaxy/io.py
+++ b/src/ewoksgalaxy/io.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from ewokscore.engine_interface import TaskGraph
 
-
 _DEFAULT_LICENSE = "MIT"
 _DEFAULT_CREATOR = [{"class": "Organization", "name": "ESRF"}]
 

--- a/src/ewoksgalaxy/tests/test_io.py
+++ b/src/ewoksgalaxy/tests/test_io.py
@@ -6,24 +6,34 @@ from ewoksgalaxy.io import ewoks_to_galaxy
 def test_ewoks_to_galaxy(ewoks_workflow):
     assert ewoks_to_galaxy(TaskGraph(ewoks_workflow)) == {
         "class": "GalaxyWorkflow",
+        "creator": [{"class": "Organization", "name": "ESRF"}],
+        "doc": "An Ewoks workflow to test Galaxy",
         "inputs": [],
-        "outputs": [],
         "id": "galaxy_test",
         "label": "An Ewoks workflow to test Galaxy",
+        "license": "MIT",
+        "outputs": [],
+        "tags": [],
         "steps": [
             {
+                "doc": "Ewoks task task1",
+                "label": "task1",
                 "state": {"a": 1},
                 "tool_id": "ewokscore.tests.examples.tasks.sumtask.SumTask",
                 "type": "tool",
                 "out": [],
             },
             {
+                "doc": "Ewoks task task2",
+                "label": "task2",
                 "state": {"b": 2},
                 "tool_id": "ewokscore.tests.examples.tasks.sumtask.SumTask",
                 "type": "tool",
                 "out": [],
             },
             {
+                "doc": "Ewoks task task3",
+                "label": "task3",
                 "state": {"b": 1},
                 "tool_id": "ewokscore.tests.examples.tasks.sumtask.SumTask",
                 "type": "tool",
@@ -36,3 +46,21 @@ def test_ewoks_to_galaxy(ewoks_workflow):
             },
         ],
     }
+
+
+def test_ewoks_to_galaxy_preserves_optional_metadata(ewoks_workflow):
+    ewoks_workflow["graph"]["annotation"] = "Workflow annotation"
+    ewoks_workflow["graph"]["creator"] = [{"class": "Organization", "name": "Ewoks"}]
+    ewoks_workflow["graph"]["license"] = "Apache-2.0"
+    ewoks_workflow["graph"]["tags"] = ["converted", "ewoks"]
+    ewoks_workflow["nodes"][0]["label"] = "sum_a"
+    ewoks_workflow["nodes"][0]["annotation"] = "First sum task"
+
+    galaxy_workflow = ewoks_to_galaxy(TaskGraph(ewoks_workflow))
+
+    assert galaxy_workflow["doc"] == "Workflow annotation"
+    assert galaxy_workflow["creator"] == [{"class": "Organization", "name": "Ewoks"}]
+    assert galaxy_workflow["license"] == "Apache-2.0"
+    assert galaxy_workflow["tags"] == ["converted", "ewoks"]
+    assert galaxy_workflow["steps"][0]["label"] == "sum_a"
+    assert galaxy_workflow["steps"][0]["doc"] == "First sum task"


### PR DESCRIPTION
CI failed when I switch readthedocs to run on ub24.04. This is an attempt to fix it.

Seems like those missing metadata are raising warnings since the release of gxformat2